### PR TITLE
Renovate/patched gatsby plugin algolia 1.x

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -121,10 +121,8 @@ const plugins: GatsbyConfig["plugins"] = [
         // optional, any index settings
         // Note: by supplying settings, you will overwrite all existing settings on the index
       },
-      enablePartialUpdates: false, // default: false
-      matchFields: ["slug", "modified"], // Array<String> default: ['modified']
       concurrentQueries: false, // default: true
-      skipIndexing:
+      dryRun:
         process.env.CF_PAGES_BRANCH !== "master" ||
         process.env.CONTENT_CHANGED === "false", // default: false, useful for e.g. preview deploys or local development
       continueOnFailure: false, // default: false, don't fail the build if algolia indexing fails

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -122,7 +122,7 @@ const plugins: GatsbyConfig["plugins"] = [
         // Note: by supplying settings, you will overwrite all existing settings on the index
       },
       concurrentQueries: false, // default: true
-      dryRun:
+      skipIndexing:
         process.env.CF_PAGES_BRANCH !== "master" ||
         process.env.CONTENT_CHANGED === "false", // default: false, useful for e.g. preview deploys or local development
       continueOnFailure: false, // default: false, don't fail the build if algolia indexing fails

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dotenv": "16.0.3",
     "gatsby": "5.9.0",
     "gatsby-image": "3.11.0",
-    "gatsby-plugin-algolia": "0.26.0",
+    "gatsby-plugin-algolia": "1.0.3",
     "gatsby-plugin-feed": "5.9.0",
     "gatsby-plugin-google-analytics": "5.9.0",
     "gatsby-plugin-google-tagmanager": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gatsby-transformer-remark": "6.9.0",
     "gatsby-transformer-sharp": "5.9.0",
     "md5-file": "5.0.0",
+    "patch-package": "^7.0.0",
     "prismjs": "1.29.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -126,7 +127,8 @@
     "clean": "gatsby clean",
     "test": "jest --config ./jest.config.js",
     "typecheck": "tsc --noEmit",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "patch-package"
   },
   "proxy": "http://localhost:8081/",
   "msw": {

--- a/patches/gatsby-plugin-algolia+1.0.3.patch
+++ b/patches/gatsby-plugin-algolia+1.0.3.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/gatsby-plugin-algolia/gatsby-node.js b/node_modules/gatsby-plugin-algolia/gatsby-node.js
+index 41d3bc2..a0adc8e 100755
+--- a/node_modules/gatsby-plugin-algolia/gatsby-node.js
++++ b/node_modules/gatsby-plugin-algolia/gatsby-node.js
+@@ -78,6 +78,7 @@ function fetchExistingObjects(index, reporter, cache) {
+  * @property {string} indexName
+  * @property {boolean} concurrentQueries
+  * @property {boolean} dryRun
++ * @property {boolean} skipIndexing
+  * @property {boolean} continueOnFailure
+  */
+ 
+@@ -95,6 +96,7 @@ exports.onPostBuild = async function (
+     queries,
+     concurrentQueries = true,
+     dryRun = false,
++    skipIndexing = false,
+     continueOnFailure = false,
+     algoliasearchOptions = {
+       timeouts: {
+@@ -108,6 +110,12 @@ exports.onPostBuild = async function (
+   const activity = reporter.activityTimer(`index to Algolia`);
+   activity.start();
+ 
++  if (skipIndexing === true) {
++    activity.setStatus(`options.skipIndexing is true; skipping indexing`);
++    activity.end();
++    return;
++  }
++
+   if (dryRun === true) {
+     console.log(
+       '\x1b[33m%s\x1b[0m',

--- a/src/gatsby/config.ts
+++ b/src/gatsby/config.ts
@@ -41,6 +41,9 @@ const algoliaQuery = `
         fields {
           slug
         }
+        internal {
+          contentDigest
+        }
         rawMarkdownBody
         timeToRead
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7423,13 +7423,12 @@ gatsby-parcel-config@^1.9.0:
     "@parcel/transformer-js" "2.8.3"
     "@parcel/transformer-json" "2.8.3"
 
-gatsby-plugin-algolia@0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-algolia/-/gatsby-plugin-algolia-0.26.0.tgz#9ed2869f51f82fcff4cb815872e679b8e2502c30"
-  integrity sha512-rBYTAPjg+NZA6JL2m6kaNwo2NlnUnSkF8LeL8ImMhvTJBor7w/NTUJh+/GPCI8Su0RbLfj98DE7C0Q4usNgQtg==
+gatsby-plugin-algolia@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-algolia/-/gatsby-plugin-algolia-1.0.3.tgz#d90335f7d962bc212620a7b9629a298199f54dd7"
+  integrity sha512-fM+Kmk0O5/m8/40I2AiILdTkn8YYRsKACpgdS5z/AwE9zXZ2uCKDadWljLZ5iynmFn84f/gNNvZsuyKlOtjOtw==
   dependencies:
     algoliasearch "^4.9.1"
-    deep-equal "^2.0.5"
     lodash.chunk "^4.2.0"
 
 gatsby-plugin-eslint@4.0.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,6 +3593,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zxing/text-encoding@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
@@ -4922,7 +4927,7 @@ ci-info@2.0.0, ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0:
+ci-info@^3.2.0, ci-info@^3.7.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
@@ -7112,6 +7117,13 @@ find-up@^6.3.0:
     locate-path "^7.1.0"
     path-exists "^5.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -8180,7 +8192,7 @@ graceful-fs@4.2.10:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -9919,6 +9931,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -10728,7 +10747,7 @@ micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
     debug "^4.0.0"
     parse-entities "^2.0.0"
 
-micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -11365,7 +11384,7 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-open@^7.0.3:
+open@^7.0.3, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -11725,6 +11744,26 @@ password-prompt@^1.0.4:
   dependencies:
     ansi-escapes "^3.1.0"
     cross-spawn "^6.0.5"
+
+patch-package@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-7.0.0.tgz#5c646b6b4b4bf37e5184a6950777b21dea6bb66e"
+  integrity sha512-eYunHbnnB2ghjTNc5iL1Uo7TsGMuXk0vibX3RFcE/CdVdXzmdbMsG/4K4IgoSuIkLTI5oHrMQk4+NkFqSed0BQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-case@^3.0.4:
   version "3.0.4"
@@ -13087,7 +13126,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.2:
+rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -13280,7 +13319,7 @@ section-matter@^1.0.0:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -13498,6 +13537,11 @@ sitemap@^7.1.1:
     "@types/sax" "^1.2.1"
     arg "^5.0.0"
     sax "^1.2.4"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
6086d5a patch: add skipIndexing
ca46c3d add: patch-package
401541c migrate: plugin configuration to v1
913888b fix(deps): update dependency gatsby-plugin-algolia to v1


skipIndexingオプションを使えるようにpatchを充てた
このオプションが無いv1系だとビルドだけしたい場合（APIアクセスが不要な状態）にもAPIアクセスが発生してしまうためエラーがでビルドが落ちる
CIで不要なAPIキーを用意したくないのでパッチを充ててAPIアクセスが不要な状態にしている
Issueは起票済み 