### PR TITLE
gatsby dev時の画像表示に対応する

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -33,6 +33,7 @@ const plugins: GatsbyConfig["plugins"] = [
           resolve: `gatsby-remark-images`,
           options: {
             maxWidth: 590,
+            withWebp: true,
           },
         },
         {


### PR DESCRIPTION
いつの間にか表示されなくなっていたので対応する

503aa29 fix: devのときに画像が表示されるようにするためWebPオプションを有効にした