### PR TITLE
スタイル修正

### DIFF
--- a/src/components/__tests__/__snapshots__/line.tsx.snap
+++ b/src/components/__tests__/__snapshots__/line.tsx.snap
@@ -27,14 +27,14 @@ exports[`Line snapshot 1`] = `
     >
       <a
         aria-label="tag"
-        className="tag"
+        className="label"
         href="/tags/a/"
       >
         A
       </a>
       <a
         aria-label="tag"
-        className="tag"
+        className="label"
         href="/tags/b/"
       >
         B

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -15,7 +15,7 @@ export const TagsWithCount = ({ tags }: TagsWithCountProps) => {
   return (
     <span className="flex flex-row flex-wrap gap-1">
       {tags.map(tag => (
-        <Link key={tag.fieldValue} aria-label="tag" className="tag" to={`/tags/${kebabCase(tag?.fieldValue || "")}/`}>
+        <Link key={tag.fieldValue} aria-label="tag" className="label" to={`/tags/${kebabCase(tag?.fieldValue || "")}/`}>
           {tag.fieldValue} ({tag.totalCount})
         </Link>
       ))}
@@ -32,7 +32,7 @@ export const Tags = (props: TagsProps) => {
   return (
     <span className="flex flex-row flex-wrap gap-1">
       {props.tags.map(tag => (
-        <Link key={tag} aria-label="tag" className="tag" to={`/tags/${kebabCase(tag || "")}/`}>
+        <Link key={tag} aria-label="tag" className="label" to={`/tags/${kebabCase(tag || "")}/`}>
           {tag}
         </Link>
       ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,18 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
-.tag {
-  @apply inline-block font-bold px-2 py-1 text-xs border border-blue-muted-300 text-blue-muted-300 rounded-md;
-}
-
-.tag:hover {
-  @apply bg-blue-muted-100;
-}
-
-.tag a:hover {
-  @apply text-gray-400;
-}
-
-.link {
-  @apply text-blue-600 hover:text-gray-600 hover:underline;
+@layer components {
+  .label {
+    @apply inline-block font-bold px-2 py-1 text-xs border border-blue-muted-300 text-blue-muted-300 rounded-md;
+  }
+  .label:hover {
+    @apply bg-blue-muted-100;
+  }
+  .label a:hover {
+    @apply text-gray-400;
+  }
+  .link {
+    @apply text-blue-600 hover:text-gray-600 hover:underline;
+  }
 }

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -59,7 +59,7 @@ const BlogPostTemplate: React.FC<PageProps<Queries.BlogPostBySlugQuery, PageCont
         </div>
 
         <nav className="py-4">
-          <ul className="flex justify-between">
+          <ul className="flex flex-row flex-wrap justify-between">
             <li className="mb-0">
               {previous && (
                 <Link className="link" to={previous.fields.slug || ""} rel="prev">
@@ -67,8 +67,7 @@ const BlogPostTemplate: React.FC<PageProps<Queries.BlogPostBySlugQuery, PageCont
                 </Link>
               )}
             </li>
-            <li className="mb-0 grow"></li>
-            <li className="mb-0">
+            <li className="mb-0 grow text-right">
               {next && (
                 <Link className="link" to={next.fields.slug || ""} rel="next">
                   {next.frontmatter.title} →


### PR DESCRIPTION
d5d72e3 fix: Codeのシンタックスハイライト内のクラスと競合してしまったので名前を変更した
783638a feat: 記事下のナビゲーションの文字列が多い場合に中途半端に折り返さずに1行使い切るように変更した
