### PR TITLE
feat: 検索スニペットの表示幅を広げる

### DIFF
--- a/functions/api/search.ts
+++ b/functions/api/search.ts
@@ -29,7 +29,7 @@ export const onRequestGet: PagesFunction<Env> = async context => {
   const result = await context.env.DB.prepare(
     `SELECT
        slug, title, tags, date, timeToRead,
-       snippet(blog_fts, 3, '<mark>', '</mark>', '...', 16) AS snippet,
+       snippet(blog_fts, 3, '<mark>', '</mark>', '...', 60) AS snippet,
        bm25(blog_fts) AS rank
      FROM blog_fts
      WHERE blog_fts MATCH ?1


### PR DESCRIPTION
## 概要
D1 FTS5 検索 (`/api/search`) のレスポンスに含まれる `snippet` のサイズを SQLite FTS5 `snippet()` の最大トークン数引数で 16 → 60 に拡張する。

## Why
- 現状の 16 トークンだとマッチ語の前後数語しか見えず、検索結果一覧から記事内容を判別しづらかった
- 「マッチ周辺の前後 1 行くらいは出ていてもよい」要望に応える
- FTS5 の `snippet()` の上限が 64 トークンなので、ぎりぎりでなく余裕をもたせて 60 に設定

## How
- `functions/api/search.ts:32` の `snippet(blog_fts, 3, '<mark>', '</mark>', '...', 16)` を 60 に変更
- それ以外の構造変化はなし。`<mark>` タグでのハイライト挙動・件数・ランキングはそのまま

## 確認観点
- [x] `pnpm typecheck` が通る
- [x] `pnpm test` が green (MSW モックなのでスニペット長そのものはテスト対象外、レスポンスシェイプは変わらない)
- [x] `pnpm lint:format` が clean
- [ ] Preview デプロイで `/api/search?q=BigQuery` 等を叩き、`snippet` がより長く返ってくることを確認
- [ ] 検索 UI のポップオーバーがマッチ周辺を含む長めの文で表示されることを目視確認 (レイアウト崩れがないか)

🤖 Generated with [Claude Code](https://claude.com/claude-code)