### PR TITLE
chore: bump swfz/failed-log-to-slack-action to v1.2.0

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -18,7 +18,7 @@ jobs:
           workflow_run: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - uses: swfz/failed-log-to-slack-action@5e26213c694dbc972a06e6cfab2e31db7453f164 # v1.1.0
+      - uses: swfz/failed-log-to-slack-action@632d666baab7b217f90d68136deed915f8cc1cfc # v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- swfz/failed-log-to-slack-action を v1.1.0 → v1.2.0 に更新 (SHA pinning)
- 対象: `.github/workflows/slack.yml`

## Test plan
- [ ] Slack通知ワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)