### PR TITLE
chore(deps): bump swfz/failed-log-to-slack-action to v1.2.0

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -18,7 +18,7 @@ jobs:
           workflow_run: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - uses: swfz/failed-log-to-slack-action@v1.1.0
+      - uses: swfz/failed-log-to-slack-action@06a3e089a86ca7114c7f8dba450dded18bb1936a # v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- `swfz/failed-log-to-slack-action` を v1.1.0 (Node 20) → v1.2.0 (Node 24) に更新
- GitHub Actions の Node.js 20 actions deprecation 警告に対応
- ルール準拠のため tag → SHA + comment 固定形式に変更

## Test plan
- [ ] CI 実行で警告が消えていることを確認